### PR TITLE
Fix deprecation warnings in example Podfiles

### DIFF
--- a/ExampleCollectionView/Podfile
+++ b/ExampleCollectionView/Podfile
@@ -2,4 +2,4 @@ platform :ios, '6.0'
 
 xcodeproj 'ExampleCollectionView'
 
-pod 'SSDataSources', :local => "../"
+pod 'SSDataSources', :path => "../"

--- a/ExampleTable/Podfile
+++ b/ExampleTable/Podfile
@@ -2,4 +2,4 @@ platform :ios, '6.0'
 
 xcodeproj 'ExampleTable'
 
-pod 'SSDataSources', :local => "../"
+pod 'SSDataSources', :path => "../"


### PR DESCRIPTION
When running `pod install` from either the ExampleCollectionView or ExampleTable projects, the following deprecation warning appeared:

```
[!] The `:local` option of the Podfile has been renamed to `:path` and is deprecated.
```

Changing to use the `:path` key removes the warning.

Great project – thanks!
