### PR TITLE
Table header/footer views

### DIFF
--- a/Example/ExampleSSDataSources/SSTableViewController.m
+++ b/Example/ExampleSSDataSources/SSTableViewController.m
@@ -39,7 +39,6 @@
         [items addObject:@( arc4random_uniform( 10000 ) )];
     
     dataSource = [[SSArrayDataSource alloc] initWithItems:items];
-    dataSource.tableView = self.tableView;
     dataSource.rowAnimation = UITableViewRowAnimationRight;
     dataSource.fallbackTableDataSource = self;
     dataSource.cellConfigureBlock = ^(SSBaseTableCell *cell, 
@@ -48,6 +47,7 @@
                                       NSIndexPath *ip ) {
         cell.textLabel.text = [number stringValue];
     };
+    dataSource.tableView = self.tableView;
 }
 
 #pragma mark - actions

--- a/Example/ExampleSSDataSourcesTests/SSBaseDataSourceTests.m
+++ b/Example/ExampleSSDataSourcesTests/SSBaseDataSourceTests.m
@@ -52,7 +52,7 @@
 
 - (void)testDefaultRowAnimation
 {
-    expect(ds.rowAnimation).to.equal(UITableViewRowAnimationNone);
+    expect(ds.rowAnimation).to.equal(UITableViewRowAnimationAutomatic);
 }
 
 #pragma mark UITableViewDataSource defaults

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Your view controller should continue to implement `UITableViewDelegate`. `SSData
 
 ## Sectioned Data Source
 
-`SSSectionedDataSource` powers a table or collection view with multiple sections. Each section is modeled with an `SSSection` object, which stores the section's items and a few other configurable bits. See `SSSectionedDataSource.h` for more details.
+`SSSectionedDataSource` powers a table or collection view with multiple sections. Each section is modeled with an `SSSection` object, which stores the section's items and a few other configurable bits. See `SSSectionedDataSource.h` and `SSSection.h` for more details.
 
 Check out the example project for a sample table that uses the sectioned data source.
 

--- a/SSDataSources.podspec
+++ b/SSDataSources.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "SSDataSources"
-  s.version      = "0.3.0"
+  s.version      = "0.3.1"
   s.summary      = "Simple data sources for your UITableView and UICollectionView."
   s.homepage     = "https://github.com/splinesoft/SSDataSources"
   s.license      = { :type => 'MIT', :file => 'LICENSE'  }

--- a/SSDataSources/SSBaseDataSource.h
+++ b/SSDataSources/SSBaseDataSource.h
@@ -82,7 +82,7 @@ typedef void (^SSCollectionSupplementaryViewConfigureBlock) (id view,           
 
 /**
  * Optional animation to use when updating the table.
- * Defaults to UITableViewRowAnimationNone.
+ * Defaults to UITableViewRowAnimationAutomatic.
  */
 @property (nonatomic, assign) UITableViewRowAnimation rowAnimation;
 

--- a/SSDataSources/SSBaseDataSource.m
+++ b/SSDataSources/SSBaseDataSource.m
@@ -16,7 +16,7 @@
     if( ( self = [super init] ) ) {
         self.cellClass = [SSBaseTableCell class];
         self.collectionViewSupplementaryElementClass = [SSBaseCollectionReusableView class];
-        self.rowAnimation = UITableViewRowAnimationNone;
+        self.rowAnimation = UITableViewRowAnimationAutomatic;
     }
     
     return self;

--- a/SSDataSources/SSBaseHeaderFooterView.h
+++ b/SSDataSources/SSBaseHeaderFooterView.h
@@ -1,0 +1,29 @@
+//
+//  SSBaseHeaderFooterView.h
+//  ExampleSSDataSources
+//
+//  Created by Jonathan Hersh on 8/29/13.
+//  Copyright (c) 2013 Splinesoft. All rights reserved.
+//
+
+/**
+ * A simple header/footer class for tableviews.
+ * Subclass me if necessary.
+ */
+
+#import <UIKit/UIKit.h>
+
+@interface SSBaseHeaderFooterView : UITableViewHeaderFooterView
+
+/**
+ * Reuse identifier. You probably don't need to override this.
+ */
++ (NSString *) identifier;
+
+/**
+ * Default constructor. 
+ * Automatically uses a reuse identifier as defined in `+identifier`.
+ */
+- (instancetype) init;
+
+@end

--- a/SSDataSources/SSBaseHeaderFooterView.m
+++ b/SSDataSources/SSBaseHeaderFooterView.m
@@ -1,0 +1,25 @@
+//
+//  SSBaseHeaderFooterView.m
+//  ExampleSSDataSources
+//
+//  Created by Jonathan Hersh on 8/29/13.
+//  Copyright (c) 2013 Splinesoft. All rights reserved.
+//
+
+#import "SSBaseHeaderFooterView.h"
+
+@implementation SSBaseHeaderFooterView
+
++ (NSString *)identifier {
+    return NSStringFromClass(self);
+}
+
+- (instancetype)init {
+    if( ( self = [self initWithReuseIdentifier:[[self class] identifier]] ) ) {
+    
+    }
+  
+    return self;
+}
+
+@end

--- a/SSDataSources/SSDataSources.h
+++ b/SSDataSources/SSDataSources.h
@@ -12,6 +12,9 @@
 #import "SSBaseTableCell.h"
 #import "SSBaseCollectionCell.h"
 #import "SSBaseCollectionReusableView.h"
+#import "SSBaseHeaderFooterView.h"
+#import "SSSection.h"
+
 #import "SSBaseDataSource.h"
 #import "SSSectionedDataSource.h"
 #import "SSArrayDataSource.h"

--- a/SSDataSources/SSSection.h
+++ b/SSDataSources/SSSection.h
@@ -1,0 +1,74 @@
+//
+//  SSSection.h
+//  ExampleSSDataSources
+//
+//  Created by Jonathan Hersh on 8/29/13.
+//  Copyright (c) 2013 Splinesoft. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+/**
+ * SSSection models a single section in a multi-sectioned table or collection view
+ * powered by `SSSectionedDataSource`.
+ * It maintains an array of items appearing within its section,
+ * plus a header and footer string.
+ */
+
+@interface SSSection : NSObject <NSCopying>
+
+@property (nonatomic, strong) NSMutableArray *items;
+
+/**
+ * Simple strings to use for headers and footers.
+ * Alternatively, you can use an `SSBaseHeaderFooterView`.
+ * See the headerClass and footerClass properties.
+ */
+@property (nonatomic, copy) NSString *header;
+@property (nonatomic, copy) NSString *footer;
+
+/**
+ * Optional custom classes to use for header and footer views.
+ * Defaults to SSBaseHeaderFooterView.
+ */
+@property (nonatomic, weak) Class headerClass;
+@property (nonatomic, weak) Class footerClass;
+
+/**
+ * Optional header and footer height.
+ * Given that `tableView:heightForHeaderInSection:` is part of 
+ * UITableViewDelegate, NOT UITableViewDataSource, 
+ * SSDataSources does not provide an implementation. These properties
+ * are merely helpers so that you can write simpler delegate code similar to this:
+ *
+   - (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section {
+        return [mySectionedDataSource heightForHeaderInSection:section];
+   }
+ *
+ */
+@property (nonatomic, assign) CGFloat headerHeight;
+@property (nonatomic, assign) CGFloat footerHeight;
+
+/**
+ * Create a section with an array of items.
+ */
++ (instancetype) sectionWithItems:(NSArray *)items;
+
+/**
+ * Sometimes I just need a section with a given number of cells,
+ * and all the cell creation and configuration is handled with values stored elsewhere.
+ * This method creates a section with the specified number of placeholder objects.
+ */
++ (instancetype) sectionWithNumberOfItems:(NSUInteger)numberOfItems;
+
+/**
+ * Return the number of items in this section.
+ */
+- (NSUInteger) numberOfItems;
+
+/**
+ * Return the item at a particular index.
+ */
+- (id) itemAtIndex:(NSUInteger)index;
+
+@end

--- a/SSDataSources/SSSection.m
+++ b/SSDataSources/SSSection.m
@@ -1,0 +1,53 @@
+//
+//  SSSection.m
+//  ExampleSSDataSources
+//
+//  Created by Jonathan Hersh on 8/29/13.
+//  Copyright (c) 2013 Splinesoft. All rights reserved.
+//
+
+#import "SSDataSources.h"
+
+@implementation SSSection
+
++ (instancetype)sectionWithItems:(NSArray *)items {
+    SSSection *section = [SSSection new];
+    section.items = [NSMutableArray arrayWithArray:items];
+    section.headerClass = [SSBaseHeaderFooterView class];
+    section.footerClass = [SSBaseHeaderFooterView class];
+  
+    return section;
+}
+
++ (instancetype)sectionWithNumberOfItems:(NSUInteger)numberOfItems {
+    NSMutableArray *array = [NSMutableArray new];
+    
+    for( NSUInteger i = 0; i < numberOfItems; i++ )
+        [array addObject:@(i)];
+    
+    return [self sectionWithItems:array];
+}
+
+- (NSUInteger)numberOfItems {
+    return [self.items count];
+}
+
+- (id)itemAtIndex:(NSUInteger)index {
+    return self.items[index];
+}
+
+#pragma mark - NSCopying
+
+- (id)copyWithZone:(NSZone *)zone {
+    SSSection *newSection = [SSSection sectionWithItems:self.items];
+    newSection.header = self.header;
+    newSection.footer = self.footer;
+    newSection.headerClass = self.headerClass;
+    newSection.footerClass = self.footerClass;
+    newSection.headerHeight = self.headerHeight;
+    newSection.footerHeight = self.footerHeight;
+  
+    return newSection;
+}
+
+@end

--- a/SSDataSources/SSSectionedDataSource.h
+++ b/SSDataSources/SSSectionedDataSource.h
@@ -7,43 +7,22 @@
 //
 
 #import "SSBaseDataSource.h"
+#import "SSSection.h"
 
 /**
  * SSSectionedDataSource is a data source for multi-sectioned table and collection views.
- * Each section is modeled using the `SSSection` object.
+ * Each section is modeled using an `SSSection` object.
  */
-
-#pragma mark - SSSection
-
-/**
- * SSSection models a single section in a multi-sectioned table or collection view.
- * It maintains an array of items appearing within its section,
- * plus a header and footer string.
- */
-@interface SSSection : NSObject <NSCopying>
-
-@property (nonatomic, strong) NSMutableArray *items;
-@property (nonatomic, copy) NSString *header;
-@property (nonatomic, copy) NSString *footer;
-
-+ (instancetype) sectionWithItems:(NSArray *)items;
-
-/**
- * Sometimes I just need a section with a given number of cells,
- * and all the cell creation and configuration is handled with values stored elsewhere.
- * This method creates a section with the specified number of placeholder objects.
- */
-+ (instancetype) sectionWithNumberOfItems:(NSUInteger)numberOfItems;
-
-- (NSUInteger) numberOfItems;
-
-- (id) itemAtIndex:(NSUInteger)index;
-
-@end
 
 #pragma mark - SSSectionedDataSource
 
 @interface SSSectionedDataSource : SSBaseDataSource
+
+/**
+ * Sections appearing in the datasource.
+ * You should not mutate this directly - rather, use the insert/move/remove accessors below.
+ */
+@property (nonatomic, strong) NSMutableArray *sections;
 
 /**
  * Create a sectioned data source with a single section.
@@ -69,6 +48,10 @@
  * Use `itemAtIndexPath:` for items.
  */
 - (SSSection *) sectionAtIndex:(NSUInteger)index;
+
+#pragma mark - Moving sections
+
+- (void) moveSectionAtIndex:(NSUInteger)fromIndex toIndex:(NSUInteger)toIndex;
 
 #pragma mark - Inserting sections
 
@@ -143,6 +126,30 @@
  * Remove multiple items in a range within a single section.
  */
 - (void) removeItemsInRange:(NSRange)range inSection:(NSUInteger)section;
+
+#pragma mark - UITableViewDelegate helpers
+
+/**
+ * Given that it is UITableViewDelegate, not UITableViewDataSource,
+ * that provides header and footer views, SSDataSources provides
+ * these helpers for constructing table header and footer views.
+ * Assumes your header/footer view is a subclass of SSBaseHeaderFooterView.
+ * See the Example project for sample usage.
+ * 
+ * You'll still need to read the section at this index to get its header/footer string,
+ * if you plan on using them. We don't want to assume you are using the textView/detailTextView
+ * properties.
+ */
+- (SSBaseHeaderFooterView *) viewForHeaderInSection:(NSUInteger)section;
+- (SSBaseHeaderFooterView *) viewForFooterInSection:(NSUInteger)section;
+
+/**
+ * As above, but for section header/footer heights.
+ * This is simply a shortcut for
+ * [myDataSource sectionAtIndex:section].headerHeight;
+ */
+- (CGFloat) heightForHeaderInSection:(NSUInteger)section;
+- (CGFloat) heightForFooterInSection:(NSUInteger)section;
 
 #pragma mark - NSIndexPath helpers
 


### PR DESCRIPTION
@segiddins @andrewsardone -- `UITableHeaderFooterView` in `SSSectionedDataSource`!
- Moved `SSSection` to its own header/impl. files
- New `SSBaseHeaderFooterView` that handles reuse identifier for you
- See the example sectioned table for sample usage

Ultimately there's not a lot going on here. No block-based creators, no multiple header/footer view classes, and I don't even get into registering header/footer classes with the table.

My thinking is that almost all of this falls under `UITableViewDelegate` and is therefore somewhat outside the scope of what I meant for `SSDataSources`. Is there enough here to be useful?
