### PR TITLE
Enable row editing by default

### DIFF
--- a/Example/ExampleSSDataSourcesTests/SSBaseDataSourceTests.m
+++ b/Example/ExampleSSDataSourcesTests/SSBaseDataSourceTests.m
@@ -70,10 +70,10 @@
     expect([ds tableView:tableView canMoveRowAtIndexPath:ip]).to.equal(NO);
 }
 
-- (void)testCanNotEditRowByDefault
+- (void)testCanEditRowByDefault
 {
     id ip = [NSIndexPath indexPathForRow:0 inSection:0];
-    expect([ds tableView:tableView canEditRowAtIndexPath:ip]).to.equal(NO);
+    expect([ds tableView:tableView canEditRowAtIndexPath:ip]).to.equal(YES);
 }
 
 #pragma mark fallbackTableDataSource

--- a/SSDataSources/SSBaseDataSource.m
+++ b/SSDataSources/SSBaseDataSource.m
@@ -114,7 +114,7 @@
         return [self.fallbackTableDataSource tableView:tv
                                  canEditRowAtIndexPath:indexPath];
     
-    return NO;
+    return YES;
 }
 
 - (void)tableView:(UITableView *)tv


### PR DESCRIPTION
According to [the documentation](http://cl.ly/image/3i331s1I0G3e) in `UITableView.h`, if a `UITableViewDataSource` doesn't implement `-tableView:canEditRowAtIndexPath:`, “all rows are assumed to be editable”.

In SSBaseDataSource’s implementation, the core logic is to rely on the `fallbackTableDataSource` if it implements the method, but otherwise return a sane default. I think the sane default should mimic the behavior of not implementing the method at all, that is, it should simply return `YES`.
