### PR TITLE
Add/remove optional Empty View

### DIFF
--- a/Example/ExampleSSDataSources/SSCollectionViewController.m
+++ b/Example/ExampleSSDataSources/SSCollectionViewController.m
@@ -85,6 +85,13 @@
     };
     
     dataSource.collectionView = self.collectionView;
+    
+    UILabel *noItemsLabel = [UILabel new];
+    noItemsLabel.text = @"No Items";
+    noItemsLabel.font = [UIFont boldSystemFontOfSize:18.0f];
+    noItemsLabel.textAlignment = NSTextAlignmentCenter;
+    
+    dataSource.emptyView = noItemsLabel;
 }
 
 - (void)addItem {

--- a/Example/ExampleSSDataSources/SSSectionedViewController.m
+++ b/Example/ExampleSSDataSources/SSSectionedViewController.m
@@ -66,6 +66,13 @@ forHeaderFooterViewReuseIdentifier:[SSBaseHeaderFooterView identifier]];
         cell.textLabel.text = [number stringValue];
     };
     dataSource.tableView = self.tableView;
+    
+    UILabel *noItemsLabel = [UILabel new];
+    noItemsLabel.text = @"No Items";
+    noItemsLabel.font = [UIFont boldSystemFontOfSize:18.0f];
+    noItemsLabel.textAlignment = NSTextAlignmentCenter;
+    
+    dataSource.emptyView = noItemsLabel;
 }
 
 + (SSSection *)sectionWithRandomNumber {

--- a/Example/ExampleSSDataSources/SSTableViewController.m
+++ b/Example/ExampleSSDataSources/SSTableViewController.m
@@ -64,6 +64,13 @@
         cell.textLabel.text = [number stringValue];
     };
     dataSource.tableView = self.tableView;
+    
+    UILabel *noItemsLabel = [UILabel new];
+    noItemsLabel.text = @"No Items";
+    noItemsLabel.font = [UIFont boldSystemFontOfSize:18.0f];
+    noItemsLabel.textAlignment = NSTextAlignmentCenter;
+    
+    dataSource.emptyView = noItemsLabel;
 }
 
 #pragma mark - actions

--- a/SSDataSources/SSArrayDataSource.m
+++ b/SSDataSources/SSArrayDataSource.m
@@ -61,8 +61,7 @@
 - (void)clearItems {
     [self.items removeAllObjects];
     
-    [self.tableView reloadData];
-    [self.collectionView reloadData];
+    [self reloadData];
 }
 
 - (void)removeAllItems {
@@ -72,8 +71,7 @@
 - (void)updateItems:(NSArray *)newItems {
     self.items = [NSMutableArray arrayWithArray:newItems];
     
-    [self.tableView reloadData];
-    [self.collectionView reloadData];
+    [self reloadData];
 }
 
 - (NSArray *)allItems {

--- a/SSDataSources/SSBaseDataSource.h
+++ b/SSDataSources/SSBaseDataSource.h
@@ -58,7 +58,7 @@ typedef void (^SSTableCellDeletionBlock) (id dataSource,           // the dataso
                                           UITableView *parentView, // the parent table view
                                           NSIndexPath *indexPath); // the indexPath being deleted
 
-#pragma mark - base data source setup
+#pragma mark - Base Data Source
 
 /**
  * The base class to use to instantiate new cells.
@@ -80,6 +80,16 @@ typedef void (^SSTableCellDeletionBlock) (id dataSource,           // the dataso
  * See block signature above.
  */
 @property (nonatomic, copy) SSCellCreationBlock cellCreationBlock;
+
+/**
+ * Optional view that will be added to the table or collection view if there
+ * are no items in the datasource, then removed again once the datasource
+ * has items.
+ *
+ * If this view's frame is equal to CGRectZero, the view's frame
+ * will be sized to match the parent table or collection view.
+ */
+@property (nonatomic, strong) UIView *emptyView;
 
 #pragma mark - UITableView
 
@@ -186,6 +196,8 @@ typedef void (^SSTableCellDeletionBlock) (id dataSource,           // the dataso
 
 - (void) insertSectionsAtIndexes:(NSIndexSet *)indexes;
 - (void) deleteSectionsAtIndexes:(NSIndexSet *)indexes;
+
+- (void) reloadData;
 
 #pragma mark - helpers
 

--- a/SSDataSources/SSCoreDataSource.m
+++ b/SSDataSources/SSCoreDataSource.m
@@ -265,6 +265,9 @@ sectionForSectionIndexTitle:(NSString *)title
     
     [self.sectionUpdates removeAllObjects];
     [self.objectUpdates removeAllObjects];
+    
+    // Hackish; force recalculation of empty view state
+    self.emptyView = self.emptyView;
 }
 
 @end

--- a/SSDataSources/SSSectionedDataSource.m
+++ b/SSDataSources/SSSectionedDataSource.m
@@ -212,9 +212,7 @@ moveRowAtIndexPath:(NSIndexPath *)sourceIndexPath
 
 - (void)clearSections {
     [self.sections removeAllObjects];
-  
-    [self.tableView reloadData];
-    [self.collectionView reloadData];
+    [self reloadData];
 }
 
 - (void)removeAllSections {


### PR DESCRIPTION
Adds an optional 'empty' `UIView` when the table or collectionview has no items, then removes the empty view when the table or collectionview has items added.

@segiddins @andrewsardone any thoughts? Methinks pretty neat, other than the admittedly-unfortunate `SSCoreDataSource` hack here :)
