### PR TITLE
Improve SSArrayDataSource scrolling performance

### DIFF
--- a/SSDataSources/SSArrayDataSource.m
+++ b/SSDataSources/SSArrayDataSource.m
@@ -53,6 +53,12 @@ static void *SSArrayKeyPathDataSourceContext = &SSArrayKeyPathDataSourceContext;
  */
 @property (nonatomic, copy) NSString *keyPath;
 
+/**
+ * The mutable proxy of items for the to-many relationship represented by the
+ * receiver’s keyPath off of the target.
+ */
+@property (nonatomic, strong) NSMutableArray *items;
+
 @end
 
 @implementation SSArrayDataSource
@@ -83,7 +89,10 @@ static void *SSArrayKeyPathDataSourceContext = &SSArrayKeyPathDataSourceContext;
  * data source.
  */
 - (NSMutableArray *)items {
-    return [self.target mutableArrayValueForKey:self.keyPath];
+    if (_items == nil) {
+        _items = [self.target mutableArrayValueForKey:self.keyPath];
+    }
+    return _items;
 }
 
 #pragma mark - Base Data source


### PR DESCRIPTION
In an app I’m working on, I noticed a not insignificant amount of time was being [spent in `-[SSArrayDataSource items]](https://cloud.githubusercontent.com/assets/14554/2980091/23433b12-dbe0-11e3-8b0f-07cde51986e0.png) due to the constant `-mutableArrayValueForKey:` message send.

This change simply internally caches the mutable array within `SSArrayDataSource`.
- [primitive trace document](http://cl.ly/3z253y0t0Z0D) with a before and after run using the a [100 rows](http://cl.ly/code/2o381P2c3c46) Example app

refs splinesoft/SSDataSources#29
