### PR TITLE
Fix empty view setup if configured before parent view

### DIFF
--- a/Example/ExampleSSDataSourcesTests/SSBaseDataSourceTests.m
+++ b/Example/ExampleSSDataSourcesTests/SSBaseDataSourceTests.m
@@ -189,4 +189,19 @@
     expect(indexPaths).to.equal(@[[NSIndexPath indexPathForRow:1 inSection:0]]);
 }
 
+#pragma mark Empty View
+
+- (void)testBasicEmptyViewVisibility
+{
+    // hidden empty view
+    SSArrayDataSource *arrayDataSource = [[SSArrayDataSource alloc] initWithItems:@[ @"item" ]];
+    arrayDataSource.tableView = tableView;
+    arrayDataSource.emptyView = [UIView new];
+    expect(arrayDataSource.emptyView.hidden).to.beTruthy();
+
+    // visible empty view
+    [arrayDataSource removeAllItems];
+    expect(arrayDataSource.emptyView.hidden).to.beFalsy();
+}
+
 @end

--- a/Example/ExampleSSDataSourcesTests/SSBaseDataSourceTests.m
+++ b/Example/ExampleSSDataSourcesTests/SSBaseDataSourceTests.m
@@ -204,4 +204,21 @@
     expect(arrayDataSource.emptyView.hidden).to.beFalsy();
 }
 
+- (void)testEmptyViewSetUpIsNotDependentOnParentViewConfiguration
+{
+    // The intent is to ensure that you can set up your emptyView *before* you
+    // assign the data source’s table or collection view.
+    SSArrayDataSource *arrayDataSource;
+
+    arrayDataSource = [[SSArrayDataSource alloc] initWithItems:@[]];
+    arrayDataSource.emptyView = [UIView new];
+    arrayDataSource.tableView = tableView;
+    expect(arrayDataSource.emptyView.hidden).to.beFalsy();
+
+    arrayDataSource = [[SSArrayDataSource alloc] initWithItems:@[]];
+    arrayDataSource.emptyView = [UIView new];
+    arrayDataSource.collectionView = collectionView;
+    expect(arrayDataSource.emptyView.hidden).to.beFalsy();
+}
+
 @end

--- a/SSDataSources/SSBaseDataSource.m
+++ b/SSDataSources/SSBaseDataSource.m
@@ -104,6 +104,8 @@
     if (tableView) {
         tableView.dataSource = self;
     }
+
+    [self _updateEmptyView];
 }
 
 - (void)setCollectionView:(UICollectionView *)collectionView {
@@ -112,6 +114,8 @@
     if (collectionView) {
         collectionView.dataSource = self;
     }
+
+    [self _updateEmptyView];
 }
 
 #pragma mark - UITableViewDataSource


### PR DESCRIPTION
Before this change, if you were to assign a data source’s `emptyView` *before* you assigned its `tableView` or `collectionView`, the `emptyView` would not be displayed when there were no items. This was because the `emptyView` was not [properly updated since at the time of assignment its parent view would be nil][1].

This is a subtle ordering bug that was bitten me several times.

Before:

```objc
dataSource.emptyView = [MyAwesomeView new];
// other stuff
dataSource.tableView = self.tableView;
// if dataSource has no items, MyAwesomeView will never appear :(
```

After:

```objc
dataSource.emptyView = [MyAwesomeView new];
// other stuff
dataSource.tableView = self.tableView;
// if dataSource has no items, MyAwesomeView will appear in all of its glory :)
```

[1]: https://github.com/splinesoft/SSDataSources/blob/2321bc79e9a9b2a537ffe8e806b08fbc021b13e2/SSDataSources/SSBaseDataSource.m#L248-L250
