### PR TITLE
Nil the tableview delegate and data sources when dealloc

### DIFF
--- a/SSDataSources/SSBaseDataSource.m
+++ b/SSDataSources/SSBaseDataSource.m
@@ -43,6 +43,10 @@
     self.collectionSupplementaryCreationBlock = nil;
     self.tableActionBlock = nil;
     self.tableDeletionBlock = nil;
+    self.tableView.delegate = nil;
+    self.tableView.dataSource = nil;
+    self.collectionView.delegate = nil;
+    self.collectionView.dataSource = nil;
 }
 
 #pragma mark - SSBaseDataSource


### PR DESCRIPTION
We were having an issue with what seems like the table view's delegates being retained. This should prevent that from happening now. 